### PR TITLE
Fixed a bug of Locus

### DIFF
--- a/techniques/Locus/src/miningChanges/CorpusCreation.java
+++ b/techniques/Locus/src/miningChanges/CorpusCreation.java
@@ -22,7 +22,7 @@ public class CorpusCreation {
 	public static String loc = main.Main.settings.get("workingLoc");
 	public static String repo = main.Main.settings.get("repoDir");
 	public static HashSet<String> concernedCommits;
-	public static HashMap<String,String> changeMap;
+	public static HashSet<String> changeMap;
 	public static HashMap<String,Integer> sourceFileIndex;
 	
 	public static void getCommitsOneLine() throws Exception{
@@ -176,16 +176,15 @@ public class CorpusCreation {
 			count++;
 			//System.out.println(count + ":" + concernedCommits.size());
 			
-			if (!changeMap.containsKey(hash)) continue;
+			if (!changeMap.contains(hash)) continue;
 			//System.out.println(fullHash);
 			// adaptpr for project ChangeLocator
 			
-			String fullHash = changeMap.get(hash);
-            String parentPath = revisionLoc + File.separator + fullHash.substring(0,2)+ File.separator +fullHash.substring(2,4);
-			String commitFile = parentPath + File.separator + fullHash + ".txt";
+            String parentPath = revisionLoc + File.separator + hash.substring(0,2)+ File.separator +hash.substring(2,4);
+			String commitFile = parentPath + File.separator + hash + ".txt";
 
 			file = new File(parentPath);
-            if (!file.exists()) file.mkdir();
+            if (!file.exists()) file.mkdirs();
 			
 			file = new File(commitFile);
 			if (!file.exists() || file.length() == 0) {

--- a/techniques/Locus/src/miningChanges/ProduceChangeLevelResults.java
+++ b/techniques/Locus/src/miningChanges/ProduceChangeLevelResults.java
@@ -80,7 +80,7 @@ public class ProduceChangeLevelResults {
 			String[] splits = line.split("\t");
 			String revisionNO = splits[0];
 			Date date = new SimpleDateFormat("EEE MMM dd HH:mm:ss yyyy Z", Locale.ENGLISH).parse(splits[2]);
-			revisionTime.put(revisionNO.substring(0,7), date.getTime());
+			revisionTime.put(revisionNO, date.getTime());
 		}
 	}
 	

--- a/techniques/Locus/src/miningChanges/ProduceFileLevelResults.java
+++ b/techniques/Locus/src/miningChanges/ProduceFileLevelResults.java
@@ -124,10 +124,10 @@ public class ProduceFileLevelResults {
 				if (description.contains("bug") || description.contains("patch") || 
 						description.contains("fix") || description.contains("issue")) {
 //				if (description.contains("fix") || description.contains("bug")) {
-					isCommitFix.put(hash.substring(0, 7), true);
+					isCommitFix.put(hash, true);
 					lines.add(hash + "\t1");
 				} else {
-					isCommitFix.put(hash.substring(0, 7), false);
+					isCommitFix.put(hash, false);
 					lines.add(hash + "\t0");
 				}
 			}
@@ -136,7 +136,7 @@ public class ProduceFileLevelResults {
 			lines = FileToLines.fileToLines(commitFix);
 			for (String line : lines) {
 				String[] split = line.split("\t");
-				isCommitFix.put(split[0].substring(0,7), split[1].equals("1"));
+				isCommitFix.put(split[0], split[1].equals("1"));
 			}
 		}	
 		
@@ -214,7 +214,8 @@ public class ProduceFileLevelResults {
 					max = fixSuspicious.get(sid);
 			
 			for (int sid : fixSuspicious.keySet()) 
-				fixSuspicious.put(sid, fixSuspicious.get(sid) / max);
+				if (max > 0.0)
+					fixSuspicious.put(sid, fixSuspicious.get(sid) / max);
 			
 			//calculate finalResults
 			for (String change : results.keySet()) {
@@ -242,10 +243,10 @@ public class ProduceFileLevelResults {
 				double score = finalRanks.get(r).getValue();
 				String filename = sourceFileIndex.get(sid);	
 				
-				// ÀüÃ¼ ·©Å·Á¤º¸ ÀúÀå
+				// ï¿½ï¿½Ã¼ ï¿½ï¿½Å·ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 				fullRanks.add(r + "\t" + score + "\t" + filename);
 				
-				// answer¿¡ ´ëÇÑ °á°ú¸¸ ÀúÀå.
+				// answerï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½.
 				if (!ansFileIndices.contains(sid)) continue;				
 				rawRanks.add(bid + "\t" +filename + "\t" + r + "\t" + score );
 				rank.add(r);

--- a/techniques/Locus/src/preprocess/ExtractCommits.java
+++ b/techniques/Locus/src/preprocess/ExtractCommits.java
@@ -20,7 +20,7 @@ public class ExtractCommits {
 	public static String loc = main.Main.settings.get("workingLoc");
 	public static String repo = main.Main.settings.get("repoDir");
 	public static HashSet<String> concernedCommits;
-	public static HashMap<String,String> changeMap;
+	public static HashSet<String> changeMap;
 	public static HashMap<String,Long> changeTime;
 	public static void indexHunks() throws Exception {
 		getCommitsOneLine();
@@ -91,17 +91,14 @@ public class ExtractCommits {
 		int max = concernedCommits.size();
 		for (String hash : concernedCommits) {
 			count++;
-			if (!changeMap.containsKey(hash)) continue;
+			if (!changeMap.contains(hash)) continue;
 
-			
-			String fullHash = changeMap.get(hash);
-			
-			File parentPath = new File(revisionLoc + File.separator + fullHash.substring(0,2)+ File.separator +fullHash.substring(2,4));
+			File parentPath = new File(revisionLoc + File.separator + hash.substring(0,2) + File.separator + hash.substring(2,4));
             //file = new File(revisionLoc + File.separator + fullHash);
 			if (!parentPath.exists())
 				parentPath.mkdirs();
 			
-			String commitFile = parentPath.getAbsolutePath() + File.separator + fullHash + ".txt";
+			String commitFile = parentPath.getAbsolutePath() + File.separator + hash + ".txt";
 			file = new File(commitFile);
 			if (!file.exists()) {
 				String content = GitHelp.gitShow(hash, repo);

--- a/techniques/Locus/src/utils/ChangeLocator.java
+++ b/techniques/Locus/src/utils/ChangeLocator.java
@@ -5,13 +5,14 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 
 public class ChangeLocator {
-	public static HashMap<String,String> shortChangeMap = null;
+	public static HashSet<String> shortChangeMap = null;
 	
-	public static HashMap<String,String> getShortChangeMap() {
+	public static HashSet<String> getShortChangeMap() {
 		if (shortChangeMap == null) {
 			shortChangeMap = readShortChangeMap();
 		} 
@@ -30,12 +31,12 @@ public class ChangeLocator {
 		return changeTime;
 	}
 	
-	public static HashMap<String,String> readShortChangeMap() {
-		HashMap<String,String> changeMap = new HashMap<String,String>();
+	public static HashSet<String> readShortChangeMap() {
+		HashSet<String> changeMap = new HashSet<String>();
 		List<String> lines = FileToLines.fileToLines(main.Main.settings.get("workingLoc") + File.separator + "logOneline.txt");
 		for (String line : lines) {
 			String[] split = line.split("\t");
-			changeMap.put(split[0].substring(0, 7), split[0]);
+			changeMap.add(split[0]);
 		}
 		return changeMap;
 	}

--- a/techniques/Locus/src/utils/GitHelp.java
+++ b/techniques/Locus/src/utils/GitHelp.java
@@ -103,7 +103,7 @@ public class GitHelp {
 			BufferedReader bw = new BufferedReader(new FileReader(new File(filename)));
 			line = bw.readLine();
 			while ( line != null) {
-				hashId = line.substring(7);
+				hashId = line.substring(8, 19);
 				line = bw.readLine();
 				if (!line.startsWith("Author")) line = bw.readLine();	
 				int nameStart = line.indexOf(":") + 1;


### PR DESCRIPTION
Hi,

I tried to use Bench4BL with CAMEL.
I found a bug of Locus. MAP and MRR are 0 for all versions of CAMEL.
The inconsistency of git hash digits among some classes is the cause.
In my fix, 11-digits hash is consistently assumed in those classes.
I appreciate if you would check this pull request.

My environment is:
- Mac OS X Mojave (10.14.1)
- git 2.19.1 (from homebrew)
- Oracle Java 1.8.0_60
